### PR TITLE
turned off docker caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       # build and push Docker image to dockerhub.
       - run: |
           TAG=0.3.0


### PR DESCRIPTION
circleci docker caching is now a "pay for feature", so it has been turned off