### PR TITLE
Align docker-compose quickstart with a3 identity server changes

### DIFF
--- a/quickstart/docker-compose/docker-compose.yml
+++ b/quickstart/docker-compose/docker-compose.yml
@@ -67,8 +67,15 @@ services:
       - 80:80
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - FLYWAY_ENABLE=true
+      - DATABASE_SERVER=a3s-postgresql
+      - DATABASE_NAME=identity_server
+      - DATABASE_PORT=5432
+      - FLYWAY_USER=postgres
+      - FLYWAY_PASSWORD=postgres
+      - FLYWAY_CONNECTION_RETRIES=5
     depends_on:
-      - a3s
+      - a3s-postgresql
 
   register-security-contract:
     networks:
@@ -85,4 +92,3 @@ services:
 
 networks:
   dokuti-quickstart:            
-

--- a/quickstart/docker-compose/run-quickstart-steps.sh
+++ b/quickstart/docker-compose/run-quickstart-steps.sh
@@ -1,0 +1,29 @@
+apk update
+apk add curl jq
+
+
+cd quickstart/docker-compose
+docker-compose up -d
+
+
+TOKEN=`curl \
+-s -v \
+-X POST http://localhost:80/connect/token \
+-H 'Content-Type: application/x-www-form-urlencoded' \
+-H 'cache-control: no-cache' \
+-d 'grant_type=password&username=dokuti-admin&password=Password1#&client_id=dokuti-test-client&client_secret=secret&scope=dokuti' \
+| jq '.access_token' -r` \
+&& echo "TOKEN is :$TOKEN"
+
+curl -s -v  \
+-H "Accept: application/json"  \
+-X POST http://localhost:8181/documents \
+-H "Authorization: Bearer $TOKEN" \
+-H "cache-control: no-cache" \
+-H "Content-Type: multipart/form-data" \
+-H "Transfer-Encoding: chunked" \
+-F "description=test initial description." \
+-F file=@sample.file.txt | jq
+
+
+docker-compose down


### PR DESCRIPTION
The [latest A3S release](https://github.com/GrindrodBank/A3S/releases/tag/v1.1.0) introduces some environment variables that `a3s-identity-server` uses to configure startup behaviour.
(specifically [PR #104 - Move IDS4 migrations to IDS4 container](https://github.com/GrindrodBank/A3S/issues/104)).

This PR aligns the quickstart docker-compose with those changes.